### PR TITLE
Fixes #6

### DIFF
--- a/CPS2231 Assignment/src/assignment4/DivisibleBy2Or3.java
+++ b/CPS2231 Assignment/src/assignment4/DivisibleBy2Or3.java
@@ -21,12 +21,15 @@ class DivisibleBy2Or3 {
 			// change the BigInteger into a byte array
 			byte[] numInByteArr = num.toByteArray();
 			
-			// divisible by 2
-			if (numInByteArr[numInByteArr.length-1] % 2 == 0) {
-				System.out.println(num);
-				numOfNum--;
-				continue;
-			}
+			// make sure the BigInteger is with 50 digits
+			if (num.toString().length()==50) {
+				
+				// divisible by 2
+				if (num.intValue() % 2 == 0) {
+					System.out.println(num);
+					numOfNum--;
+					continue;
+				}
 			
 			// divisible by 3
 			long sumOfByte = 0;


### PR DESCRIPTION
BigInteger(int numBits, Random rnd)
numBits is not the number of digits.

[Definition]
Constructs a randomly generated BigInteger, uniformly distributed over the range 0 to (2numBits - 1), inclusive. The uniformity of the distribution assumes that a fair source of random bits is provided in rnd. Note that this constructor always constructs a non-negative BigInteger.
Parameters:
numBits - maximum bitLength of the new BigInteger.
rnd - source of randomness to be used in computing the new BigInteger.
Throws:
IllegalArgumentException - numBits is negative.
See Also:
bitLength()
