### PR TITLE
fixes #9

### DIFF
--- a/CPS2231 Assignment/src/assignment4/DivisibleBy2Or3.java
+++ b/CPS2231 Assignment/src/assignment4/DivisibleBy2Or3.java
@@ -16,10 +16,9 @@ class DivisibleBy2Or3 {
 		
 		// output loop
 		while (numOfNum>0) {
+			
 			// generate a BigInteger
-			BigInteger num = new BigInteger(50,random);
-			// change the BigInteger into a byte array
-			byte[] numInByteArr = num.toByteArray();
+			BigInteger num = new BigInteger(165,random);
 			
 			// make sure the BigInteger is with 50 digits
 			if (num.toString().length()==50) {
@@ -31,16 +30,16 @@ class DivisibleBy2Or3 {
 					continue;
 				}
 			
-			// divisible by 3
-			long sumOfByte = 0;
-			for (int j = 0; j < numInByteArr.length; j++) {
-				sumOfByte += numInByteArr[j];
+				// divisible by 3
+				BigInteger three = new BigInteger("3");
+				if (num.mod(three).intValue()==0) {
+					System.out.println(num);
+					numOfNum--;
+					continue;
+				}
+				
 			}
-			if (sumOfByte%3==0) {
-				System.out.println(num);
-				numOfNum--;
-				continue;
-			}
+			
 		}
 		
 	}


### PR DESCRIPTION
BigInterger.toByteArray() is not used for spliting the digits, but
spliting to two's complement.
So numInByteArr is not 50.
改变解决方案：
调整BigInteger(int numBits, Random rnd)中numBits参数为165，使真实生成位数为50的数字
用toString().length()确保是50位
2：BigInterger().intValue()截取最后几位为int，除2余0
3：BigInterger().mod().intValue()，除3余0
